### PR TITLE
AG-8: Extend URL Text Extractor to Include Image Extraction

### DIFF
--- a/tests/test_url_text_extractor.py
+++ b/tests/test_url_text_extractor.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import patch
-from url_text_extractor import extract_text_from_url
+from url_text_extractor import extract_text_from_url, extract_images_from_url
 
 
 def test_extract_text_from_url():
@@ -8,3 +8,9 @@ def test_extract_text_from_url():
         mocked_get.return_value.status_code = 200
         mocked_get.return_value.text = '<html><body>Hello World</body></html>'
         assert extract_text_from_url('http://example.com') == 'Hello World'
+
+def test_extract_images_from_url():
+    with patch('requests.get') as mocked_get:
+        mocked_get.return_value.status_code = 200
+        mocked_get.return_value.text = '<html><body><img src="image1.jpg"><div style="background-image:url(\'image2.jpg\')"></div></body></html>'
+        assert extract_images_from_url('http://example.com') == ['image1.jpg', "image2.jpg"]

--- a/url_text_extractor.py
+++ b/url_text_extractor.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+import re
 
 
 def extract_text_from_url(url: str) -> str:
@@ -8,6 +9,19 @@ def extract_text_from_url(url: str) -> str:
     soup = BeautifulSoup(response.text, 'html.parser')
     return soup.get_text()
 
+
+def extract_images_from_url(url: str) -> list:
+    response = requests.get(url)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, 'html.parser')
+    images = [img['src'] for img in soup.find_all('img') if img.get('src')]
+    # Extract images from CSS backgrounds
+    styles = soup.find_all(style=True)
+    background_images = [re.findall(r"url\('(.*)'\)", style['style'])[0] for style in styles if 'background-image' in style['style']]
+    images.extend(background_images)
+    return images
+
 if __name__ == '__main__':
-    url = input('Enter the URL to extract text from: ')
-    print(extract_text_from_url(url))
+    url = input('Enter the URL to extract text and images from: ')
+    print('Extracted Text:', extract_text_from_url(url))
+    print('Extracted Images:', extract_images_from_url(url))


### PR DESCRIPTION
This PR extends the functionality of the URL text extractor to also extract all images from a webpage. This includes images from `<img>` tags as well as images set as backgrounds in other HTML tags using CSS styles.

### Test Plan

pytest