### PR TITLE
AG-8: Extend URL Text Extractor to Include Image Extraction

### DIFF
--- a/tests/test_url_text_extractor.py
+++ b/tests/test_url_text_extractor.py
@@ -1,10 +1,13 @@
 import pytest
 from unittest.mock import patch
-from url_text_extractor import extract_text_from_url
+from url_text_extractor import extract_text_and_images_from_url
 
 
-def test_extract_text_from_url():
+def test_extract_text_and_images_from_url():
     with patch('requests.get') as mocked_get:
         mocked_get.return_value.status_code = 200
-        mocked_get.return_value.text = '<html><body>Hello World</body></html>'
-        assert extract_text_from_url('http://example.com') == 'Hello World'
+        mocked_get.return_value.text = "<html><body>Hello World<img src='example.jpg' style='background-image: url(example-bg.jpg);'></body></html>"
+        result = extract_text_and_images_from_url('http://example.com')
+        assert result['text'] == 'Hello World'
+        assert 'example.jpg' in result['images']
+        assert 'example-bg.jpg' in result['images']

--- a/url_text_extractor.py
+++ b/url_text_extractor.py
@@ -2,12 +2,31 @@ import requests
 from bs4 import BeautifulSoup
 
 
-def extract_text_from_url(url: str) -> str:
+def extract_images_from_html(html_content: str) -> list:
+    soup = BeautifulSoup(html_content, 'html.parser')
+    images = []
+    # Extract from <img> tags
+    for img in soup.find_all('img'):
+        if img.get('src'):
+            images.append(img.get('src'))
+    # Extract from any tag with a background-image
+    for tag in soup.find_all(style=True):
+        style = tag['style']
+        if 'background-image' in style:
+            url_start = style.find('url(') + 4
+            url_end = style.find(')', url_start)
+            images.append(style[url_start:url_end])
+    return images
+
+def extract_text_and_images_from_url(url: str) -> dict:
     response = requests.get(url)
     response.raise_for_status()  # Ensure the response is successful
-    soup = BeautifulSoup(response.text, 'html.parser')
-    return soup.get_text()
+    text = BeautifulSoup(response.text, 'html.parser').get_text()
+    images = extract_images_from_html(response.text)
+    return {'text': text, 'images': images}
 
 if __name__ == '__main__':
-    url = input('Enter the URL to extract text from: ')
-    print(extract_text_from_url(url))
+    url = input('Enter the URL to extract text and images from: ')
+    result = extract_text_and_images_from_url(url)
+    print('Extracted Text:', result['text'])
+    print('Extracted Images:', result['images'])


### PR DESCRIPTION
This PR extends the functionality of the URL text extractor to also extract all images from a given URL. Images are extracted from both <img> tags and other HTML tags that might contain image data, such as CSS backgrounds.

### Test Plan

pytest