### PR TITLE
AG-7: Add functionality to extract and print text from a URL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from bs4 import BeautifulSoup
+import requests
+
+app = FastAPI()
+
+@app.get("/scrape-text")
+def scrape_text(url: str) -> str:
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, 'html.parser')
+    text = soup.get_text()
+    print(text)
+    return text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 fastapi
 pytest
 uvicorn
+requests
+beautifulsoup4
+httpx

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,12 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from unittest.mock import patch
+
+@patch('requests.get')
+def test_scrape_text(mock_get):
+    mock_get.return_value.content = b'<html><body><p>Example Domain</p></body></html>'
+    client = TestClient(app)
+    response = client.get("/scrape-text", params={"url": "https://example.com"})
+    assert response.status_code == 200
+    assert 'Example Domain' in response.text


### PR DESCRIPTION
This PR introduces a new feature that allows the extraction of all text from a given URL and prints it. This is useful for web scraping tasks where only the text content is needed.

### Test Plan

pytest