### PR TITLE
AG-7: Add functionality to extract and print text from a URL

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from bs4 import BeautifulSoup
+import requests
+
+app = FastAPI()
+
+@app.get("/scrape-text")
+def scrape_text(url: str) -> str:
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, 'html.parser')
+    text = soup.get_text()
+    print(text)
+    return text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 fastapi
 pytest
 uvicorn
+requests
+beautifulsoup4
+httpx
+pytest-mock

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,14 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from unittest.mock import patch
+
+@patch('requests.get')
+def test_scrape_text(mock_get):
+    mock_response = mock_get.return_value
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>Example Domain</p></body></html>'
+    client = TestClient(app)
+    response = client.get("/scrape-text", params={"url": "https://example.com"})
+    assert response.status_code == 200
+    assert 'Example Domain' in response.text


### PR DESCRIPTION
This PR introduces a new feature that allows the FastAPI application to extract all text from a given URL and print it. This is achieved using the `requests` and `beautifulsoup4` libraries to fetch the webpage and parse its content.

### Test Plan

pytest