### PR TITLE
AG-8: Extract all images from HTML content

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+from fastapi import FastAPI
+from bs4 import BeautifulSoup
+import requests
+
+app = FastAPI()
+
+@app.get("/scrape-text")
+def scrape_text(url: str) -> str:
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, 'html.parser')
+    text = soup.get_text()
+    print(text)
+    return text

--- a/app/main.py
+++ b/app/main.py
@@ -11,3 +11,20 @@ def scrape_text(url: str) -> str:
     text = soup.get_text()
     print(text)
     return text
+
+@app.get("/scrape-images")
+def scrape_images(url: str) -> list:
+    response = requests.get(url)
+    soup = BeautifulSoup(response.content, 'html.parser')
+    images = []
+    for img in soup.find_all('img'):
+        if img.get('src'):
+            images.append(img.get('src'))
+    for tag in soup.find_all(style=True):
+        style = tag['style']
+        if 'background-image' in style:
+            url_start = style.find('url(') + 4
+            url_end = style.find(')', url_start)
+            image_url = style[url_start:url_end].strip('"\'')
+            images.append(image_url)
+    return images

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 fastapi
 pytest
 uvicorn
+requests
+beautifulsoup4
+httpx
+pytest-mock

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,14 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from unittest.mock import patch
+
+@patch('requests.get')
+def test_scrape_text(mock_get):
+    mock_response = mock_get.return_value
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><p>Example Domain</p></body></html>'
+    client = TestClient(app)
+    response = client.get("/scrape-text", params={"url": "https://example.com"})
+    assert response.status_code == 200
+    assert 'Example Domain' in response.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,3 +12,14 @@ def test_scrape_text(mock_get):
     response = client.get("/scrape-text", params={"url": "https://example.com"})
     assert response.status_code == 200
     assert 'Example Domain' in response.text
+
+@patch('requests.get')
+def test_scrape_images(mock_get):
+    mock_response = mock_get.return_value
+    mock_response.status_code = 200
+    mock_response.content = b'<html><body><img src="https://example.com/image.png"><div style="background-image: url(\'https://example.com/bg.png\');"></div></body></html>'
+    client = TestClient(app)
+    response = client.get("/scrape-images", params={"url": "https://example.com"})
+    assert response.status_code == 200
+    assert 'https://example.com/image.png' in response.json()
+    assert 'https://example.com/bg.png' in response.json()


### PR DESCRIPTION
This PR extends the functionality of the FastAPI application to extract all images from HTML content, not just from <img> tags but also from other HTML elements that might contain image data, such as CSS backgrounds.

### Test Plan

pytest