### PR TITLE
AG-30: Fix Template Not Found Error on Index Page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from bs4 import BeautifulSoup
 import requests
 
 app = FastAPI()
-templates = Jinja2Templates(directory="templates")
+templates = Jinja2Templates(directory="app/templates")
 
 @app.get("/", response_class=HTMLResponse)
 def read_root(request: Request):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,6 +3,19 @@ from fastapi.testclient import TestClient
 from app.main import app
 from unittest.mock import patch
 
+class MockTemplate:
+    def render(self, context):
+        return 'index.html'
+
+@patch('fastapi.templating.Jinja2Templates.TemplateResponse')
+def test_template_loading(mock_template_response):
+    mock_template = MockTemplate()
+    mock_template_response.return_value = mock_template.render({})
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert 'index.html' in response.text
+
 @patch('requests.get')
 def test_extract_content(mock_get):
     mock_response = mock_get.return_value


### PR DESCRIPTION
This PR addresses the issue where navigating to the index page results in a `TemplateNotFound` error for `index.html`. The error was due to the incorrect directory path for the Jinja2 templates. The path has been corrected to ensure that the template is properly located and loaded.

### Test Plan

pytest