### PR TITLE
AG-35: Fix Invisible Images on Extraction Results Page

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -36,7 +36,7 @@
     {% for image in images %}
     <div class="flex flex-col items-center mb-4">
         <canvas id="canvas{{ loop.index }}" width="500" height="300"></canvas>
-        <img id="image{{ loop.index }}" src="{{ image }}" alt="Extracted Image" class="hidden">
+        <img id="image{{ loop.index }}" src="{{ image }}" alt="Extracted Image" class="">
         <input type="text" id="text{{ loop.index }}" class="mt-2">
     </div>
     {% endfor %}


### PR DESCRIPTION
This PR addresses the issue where images were not visible on the extraction results page. The images were mistakenly set to 'hidden' in the HTML. This fix ensures that images are visible and can be interacted with, including dragging and dropping text on top of them.

### Test Plan

pytest