### PR TITLE
Fix Text Overlay on Images

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -48,9 +48,9 @@
     <h2 class="text-lg">Extracted Images:</h2>
     {% for image in images %}
     <div class="flex flex-col items-center mb-4">
-        <canvas id="canvas{{ loop.index }}" width="500" height="300"></canvas>
-        <img id="image{{ loop.index }}" src="{{ image }}" alt="Extracted Image" class="">
-        <input type="text" id="text{{ loop.index }}" class="mt-2 text-input" data-canvas="canvas{{ loop.index }}">
+        <canvas id="canvas{{ loop.index }}" width="500" height="300" style="position: relative;"></canvas>
+        <img id="image{{ loop.index }}" src="{{ image }}" alt="Extracted Image" class="absolute top-0 left-0 w-full h-full">
+        <input type="text" id="text{{ loop.index }}" class="mt-2 text-input" data-canvas="canvas{{ loop.index }}" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 10; background: rgba(255, 255, 255, 0.5);">
     </div>
     {% endfor %}
     <br>


### PR DESCRIPTION
This PR addresses the issue where the text overlay appears too far from the image. The changes ensure that the text is overlayed directly on the image and cannot move outside the boundaries of the image. This sets the groundwork for future enhancements such as downloading images with the overlaid text.

### Test Plan

pytest