### PR TITLE
Fix text input size and enable drag and drop for overlayed text

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -22,8 +22,8 @@
                 listeners: {
                     move(event) {
                         var target = event.target,
-                            x = (parseFloat(target.getAttribute('data-x')) || 0),
-                            y = (parseFloat(target.getAttribute('data-y')) || 0),
+                            x = (parseFloat(target.getAttribute('data-x')) or 0),
+                            y = (parseFloat(target.getAttribute('data-y')) or 0),
                             width = event.rect.width,
                             height = event.rect.height;
                         target.style.width = width + 'px';
@@ -32,7 +32,16 @@
                     }
                 }
             });
-            interact('.text-input').on('input', function (event) {
+            interact('.text-input').draggable({
+                onmove: function (event) {
+                    var target = event.target,
+                        x = (parseFloat(target.getAttribute('data-x')) || 0) + event.dx,
+                        y = (parseFloat(target.getAttribute('data-y')) || 0) + event.dy;
+                    target.style.transform = 'translate(' + x + 'px, ' + y + 'px)';
+                    target.setAttribute('data-x', x);
+                    target.setAttribute('data-y', y);
+                }
+            }).on('input', function (event) {
                 var canvas = document.querySelector('#' + event.target.dataset.canvas);
                 var ctx = canvas.getContext('2d');
                 ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -50,7 +59,7 @@
     <div class="flex flex-col items-center mb-4 relative">
         <canvas id="canvas{{ loop.index }}" width="500" height="300" class="z-10"></canvas>
         <img id="image{{ loop.index }}" src="{{ image }}" alt="Extracted Image" class="absolute top-0 left-0 w-full h-full z-0">
-        <input type="text" id="text{{ loop.index }}" class="mt-2 text-input" data-canvas="canvas{{ loop.index }}" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: 20; background: rgba(255, 255, 255, 0.5);">
+        <input type="text" id="text{{ loop.index }}" class="mt-2 text-input" data-canvas="canvas{{ loop.index }}" style="position: absolute; top: 0; left 0; width: 100%; height: 100%; z-index: 20; background: rgba(255, 255, 255, 0.5); font-size: 16px;">
     </div>
     {% endfor %}
     <br>


### PR DESCRIPTION
This PR addresses the issues in ticket AG-39 by increasing the size of the text input and enabling drag and drop functionality for the overlayed text on images.

### Test Plan

pytest