### PR TITLE
Add Download Feature for Images with Overlayed Text

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -60,6 +60,7 @@
         <canvas id="canvas{{ loop.index }}" width="500" height="300" class="z-10"></canvas>
         <img id="image{{ loop.index }}" src="{{ image }}" alt="Extracted Image" class="absolute top-0 left-0 w-full h-full z-0">
         <input type="text" id="text{{ loop.index }}" class="mt-2 text-input" data-canvas="canvas{{ loop.index }}" style="position: absolute; top: 0; left 0; width: 100%; height: 100%; z-index: 20; background: rgba(255, 255, 255, 0.5); font-size: 16px;">
+        <button onclick="downloadImage('canvas{{ loop.index }}')" class="mt-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">Download</button>
     </div>
     {% endfor %}
     <br>


### PR DESCRIPTION
This PR adds the ability to download images with overlayed text individually from the results page. Each image will have a corresponding download button that users can click to download the image directly.

### Test Plan

pytest