### PR TITLE
Fix text and headlines display

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -53,4 +53,4 @@ def extract_content(request: Request, url: str) -> HTMLResponse:
     for image_url, headline in results:
         images.append(image_url)
         headlines.append(headline)
-    return templates.TemplateResponse("results.html", {"request": request, "images": images, "headlines": headlines})
+    return templates.TemplateResponse("results.html", {"request": request, "images": images, "headlines": headlines, "text": text})

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -9,9 +9,12 @@
     <h1>Extraction Results</h1>
     <h2>Extracted Text:</h2>
     <p>{{ text }}</p>
-    <h2>Extracted Images:</h2>
-    {% for image in images %}
-    <img src="{{ image }}" alt="Extracted Image" style="max-width: 100%; height: auto;">
+    <h2>Extracted Images and Headlines:</h2>
+    {% for image, headline in zip(images, headlines) %}
+    <div>
+        <img src="{{ image }}" alt="Extracted Image" style="max-width: 100%; height: auto;">
+        <p>{{ headline }}</p>
+    </div>
     {% endfor %}
     <br>
     <a href="/">Go back</a>


### PR DESCRIPTION
This PR addresses the ticket AG-48 by updating the results.html template to correctly display the extracted text and the headlines for each image. It also ensures that the extracted text and headlines are properly passed from the backend to the frontend.

### Test Plan

pytest