### PR TITLE
Fix Jinja2 Template Error: 'zip' is Undefined

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,9 @@ def get_openai_client() -> OpenAI:
 app = FastAPI()
 templates = Jinja2Templates(directory="app/templates")
 
+# Enable 'zip' in Jinja2 environment
+templates.env.globals.update(zip=zip)
+
 n_images = int(os.getenv('N_IMAGES', '10'))
 
 def generate_headline(description: str, image_url: str) -> str:


### PR DESCRIPTION
This PR addresses the issue where the 'zip' function was not recognized in the Jinja2 template used in the results.html. The fix involves enabling the 'zip' function globally in the Jinja2 environment so it can be used within the template.

### Test Plan

pytest