### PR TITLE
AG-53: Subtask - Text is always overlayed

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -9,7 +9,7 @@
         .draggable {
             display: inline-block;
             padding: 0.5em;
-            background-color: #f0f0f0;
+            background-color: rgba(240, 240, 240, 0.7);
             border: 1px solid #ccc;
             cursor: move;
             z-index: 10; /* Ensure draggable elements are on top */
@@ -18,8 +18,13 @@
             position: relative;
             display: inline-block;
         }
+        .dropzone img {
+            display: block;
+        }
         .dropzone .draggable {
             position: absolute;
+            top: 0;
+            left: 0;
         }
     </style>
 </head>

--- a/cypress/e2e/overlay_text.cy.js
+++ b/cypress/e2e/overlay_text.cy.js
@@ -19,4 +19,14 @@ describe('Overlay Text with interact.js', () => {
       });
     });
   });
+
+  it('should display the headline on top of the image', () => {
+    cy.visit('/extract-content?url=https://thinkingofbermuda.com/');
+
+    cy.get('.dropzone').first().within(() => {
+      cy.get('img').should('exist');
+      cy.get('.draggable').should('exist');
+      cy.get('.draggable').should('have.css', 'position', 'absolute');
+    });
+  });
 });


### PR DESCRIPTION
Updated the `results.html` file to ensure the overlayed text appears on top of the image. Updated the Cypress E2E test to verify the text overlay functionality.

### Test Plan

pytest