### PR TITLE
AG-54: Add Download Button for Images with Overlayed Text

### DIFF
--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -37,6 +37,7 @@
     <div class="dropzone">
         <img src="{{ image }}" alt="Extracted Image" style="max-width: 100%; height: auto;">
         <div class="draggable" data-headline="{{ headline }}">{{ headline }}</div>
+        <button onclick="downloadImageWithText('{{ image }}', '{{ headline }}')">Download</button>
     </div>
     {% endfor %}
     <br>
@@ -67,6 +68,26 @@
 
             target.setAttribute('data-x', x);
             target.setAttribute('data-y', y);
+        }
+
+        function downloadImageWithText(imageUrl, text) {
+            const img = new Image();
+            img.crossOrigin = 'Anonymous';
+            img.src = imageUrl;
+            img.onload = function() {
+                const canvas = document.createElement('canvas');
+                const ctx = canvas.getContext('2d');
+                canvas.width = img.width;
+                canvas.height = img.height;
+                ctx.drawImage(img, 0, 0);
+                ctx.font = '20px Arial';
+                ctx.fillStyle = 'black';
+                ctx.fillText(text, 10, img.height - 30);
+                const link = document.createElement('a');
+                link.download = 'image_with_text.png';
+                link.href = canvas.toDataURL('image/png');
+                link.click();
+            };
         }
     </script>
 </body>

--- a/cypress/e2e/download_image.cy.js
+++ b/cypress/e2e/download_image.cy.js
@@ -1,0 +1,12 @@
+describe('Download Image with Overlayed Text', () => {
+  it('should download the image with the overlayed text when the download button is clicked', () => {
+    cy.visit('/extract-content?url=https://thinkingofbermuda.com/');
+
+    cy.get('.dropzone').first().within(() => {
+      cy.get('button').contains('Download').click();
+
+      // We can't verify the download directly, but we can ensure the button exists and is clickable
+      cy.get('button').contains('Download').should('exist');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a download button below each image that allows users to download the image along with the overlayed text.

### Test Plan

pytest / cypress